### PR TITLE
fix: parse legacy change mode edits

### DIFF
--- a/src/utils/changeModeParser.ts
+++ b/src/utils/changeModeParser.ts
@@ -39,7 +39,7 @@ export function parseChangeModeOutput(geminiResponse: string): ChangeModeEdit[] 
   }
 
   if (edits.length === 0) {
-    const editPattern = /\/old\/ \* (.+?) 'start:' (\d+)\n([\s\S]*?)\n\/\/ 'end:' (\d+)\s*\n\s*\\new\\ \* (.+?) 'start:' (\d+)\n([\s\S]*?)\n\/\/ 'end:' (\d+)/g;
+    const editPattern = /\/old\/ \* (.+?) 'start:' (\d+)\n([\s\S]*?)\n\/\/ 'end:' (\d+)\s*\n\s*\/new\/ \* (.+?) 'start:' (\d+)\n([\s\S]*?)\n\/\/ 'end:' (\d+)/g;
 
     while ((match = editPattern.exec(geminiResponse)) !== null) {
       const [

--- a/tests/changeModeParser.test.ts
+++ b/tests/changeModeParser.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { parseChangeModeOutput } from '../src/utils/changeModeParser.js';
+
+describe('parseChangeModeOutput', () => {
+  it('parses /old/ and /new/ formatted responses', () => {
+    const response = `/old/ * src/index.ts 'start:' 1\nconsole.log('old');\n// 'end:' 1\n\n/new/ * src/index.ts 'start:' 1\nconsole.log('new');\n// 'end:' 1`;
+    const edits = parseChangeModeOutput(response);
+    expect(edits).toHaveLength(1);
+    expect(edits[0]).toMatchObject({
+      filename: 'src/index.ts',
+      oldCode: "console.log('old');",
+      newCode: "console.log('new');",
+      oldStartLine: 1,
+      oldEndLine: 1,
+      newStartLine: 1,
+      newEndLine: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix regex for legacy change mode `/old/` and `/new/` sections
- add coverage for fallback format in `parseChangeModeOutput`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fb733c7a4832a9848ff821fad44bc

## Summary by Sourcery

Fix regex for legacy change mode parsing and add fallback format coverage

Bug Fixes:
- Correct regex to properly match "/new/" sections in legacy change mode edits

Tests:
- Add unit tests covering the fallback output format in parseChangeModeOutput