### PR TITLE
docs: fix typo in funding page

### DIFF
--- a/docs/funding.md
+++ b/docs/funding.md
@@ -20,7 +20,7 @@ layout: funding
   
   <ul>
     <li><strong>Docs & Listing:</strong> Updating and maintaining the documentation website & outreach</li>
-    <li><strong>API Testing Credits:</strong> Funds are used for testing various deployements of gemini-mcp-tool on popular clients.</li>
+    <li><strong>API Testing Credits:</strong> Funds are used for testing various deployments of gemini-mcp-tool on popular clients.</li>
   </ul>
   
   <div class="progress-bar">

--- a/docs/funding.md
+++ b/docs/funding.md
@@ -20,7 +20,7 @@ layout: funding
   
   <ul>
     <li><strong>Docs & Listing:</strong> Updating and maintaining the documentation website & outreach</li>
-    <li><strong>API Testing Credits:</strong> Funds are used for testing various deployments of gemini-mcp-tool on popular clients.</li>
+    <li><strong>API Testing Credits:</strong> Funds are used for testing various deployments of `Gemini MCP Tool` on popular clients.</li>
   </ul>
   
   <div class="progress-bar">


### PR DESCRIPTION
## Summary
- fix spelling in funding documentation

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `codespell docs/funding.md`


------
https://chatgpt.com/codex/tasks/task_e_688fb8bcd23c832a81d69d5fbc862cdf

## Summary by Sourcery

Documentation:
- Fix typo: change “deployements” to “deployments” in docs/funding.md