### PR TITLE
fix: clean up no-edits message in change mode

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const ERROR_MESSAGES = {
   QUOTA_EXCEEDED_SHORT: "⚠️ Gemini 2.5 Pro daily quota exceeded. Please retry with model: 'gemini-2.5-flash'",
   TOOL_NOT_FOUND: "not found in registry",
   NO_PROMPT_PROVIDED: "Please provide a prompt for analysis. Use @ syntax to include files (e.g., '@largefile.js explain what this does') or ask general questions",
+  CHANGE_MODE_NO_EDITS: "No edits found in Gemini's response. Please ensure Gemini uses the OLD/NEW format.",
 } as const;
 
 // Status messages

--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -164,7 +164,7 @@ export async function processChangeModeOutput(
   const edits = parseChangeModeOutput(rawResult);
 
   if (edits.length === 0) {
-    return `No edits found in Gemini's response. Please ensure Gemini uses the OLD/NEW format. \n\n${rawResult}`;
+    return `${ERROR_MESSAGES.CHANGE_MODE_NO_EDITS}\n\n${rawResult}`;
   }
 
   // Validate edits

--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -162,9 +162,9 @@ export async function processChangeModeOutput(
   
   // Parse OLD/NEW format
   const edits = parseChangeModeOutput(rawResult);
-  
+
   if (edits.length === 0) {
-    return `No edits found in Gemini's response. Please ensure Gemini uses the OLD/NEW format. \n\n+ ${rawResult}`;
+    return `No edits found in Gemini's response. Please ensure Gemini uses the OLD/NEW format. \n\n${rawResult}`;
   }
 
   // Validate edits

--- a/tests/geminiExecutor.test.ts
+++ b/tests/geminiExecutor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, afterEach, expect, vi } from 'vitest';
 import { spawn } from 'child_process';
 import { executeGeminiCLI, processChangeModeOutput } from '../src/utils/geminiExecutor.js';
+import { ERROR_MESSAGES } from '../src/constants.js';
 
 vi.mock('child_process', () => ({
   spawn: vi.fn(),
@@ -98,7 +99,7 @@ describe('processChangeModeOutput', () => {
     const raw = 'unexpected output';
     const result = await processChangeModeOutput(raw);
     expect(result).toBe(
-      `No edits found in Gemini's response. Please ensure Gemini uses the OLD/NEW format. \n\n${raw}`
+      `${ERROR_MESSAGES.CHANGE_MODE_NO_EDITS}\n\n${raw}`
     );
   });
 });

--- a/tests/geminiExecutor.test.ts
+++ b/tests/geminiExecutor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, afterEach, expect, vi } from 'vitest';
 import { spawn } from 'child_process';
-import { executeGeminiCLI } from '../src/utils/geminiExecutor.js';
+import { executeGeminiCLI, processChangeModeOutput } from '../src/utils/geminiExecutor.js';
 
 vi.mock('child_process', () => ({
   spawn: vi.fn(),
@@ -90,5 +90,15 @@ describe('executeGeminiCLI', () => {
     const args = (spawn as unknown as vi.Mock).mock.calls[0][1] as string[];
     const promptArgIndex = args.indexOf('-p') + 1;
     expect(args[promptArgIndex]).toBe(`"${prompt.replace(/"/g, '""')}"`);
+  });
+});
+
+describe('processChangeModeOutput', () => {
+  it('returns raw result when no edits are found', async () => {
+    const raw = 'unexpected output';
+    const result = await processChangeModeOutput(raw);
+    expect(result).toBe(
+      `No edits found in Gemini's response. Please ensure Gemini uses the OLD/NEW format. \n\n${raw}`
+    );
   });
 });


### PR DESCRIPTION
## Summary
- remove stray '+' from change-mode no-edits message
- test that `processChangeModeOutput` returns raw result without extra characters

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fb8c63fb0832a871883c0dab49508

## Summary by Sourcery

Clean up the no-edits message formatting in change mode by removing an unintended '+' prefix and add a corresponding test to ensure the output is returned correctly.

Bug Fixes:
- Remove stray '+' character from the no-edits-found message in change mode

Tests:
- Add unit test to verify processChangeModeOutput returns the raw result without extra characters when no edits are found