### PR TITLE
docs: document brainstorming and change-mode chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ The sandbox mode allows you to safely test code changes, run scripts, or execute
 - `use gemini sandbox to install numpy and create a data visualization`
 - `test this code safely: Create a script that makes HTTP requests to an API`
 
+### Brainstorming Sessions
+
+- `brainstorm ways to improve developer onboarding using design-thinking`
+- `generate 5 marketing campaign ideas with constraints: budget under $500`
+
+### Handling Large Edit Suggestions
+
+- `ask gemini to refactor @src/**/*.ts changeMode:true`
+- `/gemini-cli:fetch-chunk cacheKey=<key> chunkIndex=2`
+
 ### Tools (for the AI)
 
 These tools are designed to be used by the AI assistant.
@@ -147,6 +157,13 @@ These tools are designed to be used by the AI assistant.
   - **`prompt`** (required): The analysis request. Use the `@` syntax to include file or directory references (e.g., `@src/main.js explain this code`) or ask general questions (e.g., `Please use a web search to find the latest news stories`).
   - **`model`** (optional): The Gemini model to use. Defaults to `gemini-2.5-pro`.
   - **`sandbox`** (optional): Set to `true` to run in sandbox mode for safe code execution.
+  - **`changeMode`** (optional): When `true`, returns structured edit suggestions that can be applied directly. Large change-mode responses can be retrieved in chunks using `fetch-chunk`.
+- **`brainstorm`**: Generates structured brainstorming ideas using frameworks like SCAMPER or design thinking.
+  - **`prompt`** (required): The challenge or question to explore.
+  - Additional options: `methodology`, `domain`, `constraints`, `existingContext`, `ideaCount`, `includeAnalysis`.
+- **`fetch-chunk`**: Retrieves cached chunks from a previous `ask-gemini` changeMode response.
+  - **`cacheKey`** (required): Provided in the initial changeMode response.
+  - **`chunkIndex`** (required): Which chunk to fetch (1-based index).
 - **`sandbox-test`**: Safely executes code or commands in Gemini's sandbox environment. Always runs in sandbox mode.
   - **`prompt`** (required): Code testing request (e.g., `Create and run a Python script that...` or `@script.py Run this safely`).
   - **`model`** (optional): The Gemini model to use.
@@ -157,12 +174,16 @@ These tools are designed to be used by the AI assistant.
 
 You can use these commands directly in Claude Code's interface (compatibility with other clients has not been tested).
 
-- **/analyze**: Analyzes files or directories using Gemini, or asks general questions.
-  - **`prompt`** (required): The analysis prompt. Use `@` syntax to include files (e.g., `/analyze prompt:@src/ summarize this directory`) or ask general questions (e.g., `/analyze prompt:Please use a web search to find the latest news stories`).
-- **/sandbox**: Safely tests code or scripts in Gemini's sandbox environment.
-  - **`prompt`** (required): Code testing request (e.g., `/sandbox prompt:Create and run a Python script that processes CSV data` or `/sandbox prompt:@script.py Test this script safely`).
-- **/help**: Displays the Gemini CLI help information.
-- **/ping**: Tests the connection to the server.
+- **/gemini-cli:analyze**: Analyzes files or directories using Gemini, or asks general questions.
+  - **`prompt`** (required): The analysis prompt. Use `@` syntax to include files (e.g., `/gemini-cli:analyze prompt:@src/ summarize this directory`) or ask general questions (e.g., `/gemini-cli:analyze prompt:Please use a web search to find the latest news stories`).
+  - **`changeMode`** (optional): Returns structured edit suggestions. Large change-mode responses will include a `cacheKey` for use with `/gemini-cli:fetch-chunk`.
+- **/gemini-cli:sandbox**: Safely tests code or scripts in Gemini's sandbox environment.
+  - **`prompt`** (required): Code testing request (e.g., `/gemini-cli:sandbox prompt:Create and run a Python script that processes CSV data` or `/gemini-cli:sandbox prompt:@script.py Test this script safely`).
+- **/gemini-cli:brainstorm**: Generates structured ideas using creative methodologies.
+  - **`prompt`** (required): The challenge to explore. Optional arguments like `methodology` or `ideaCount` refine the session.
+- **/gemini-cli:fetch-chunk**: Retrieves additional change-mode edits using a provided `cacheKey` and `chunkIndex`.
+- **/gemini-cli:help**: Displays the Gemini CLI help information.
+- **/gemini-cli:ping**: Tests the connection to the server.
   - **`message`** (optional): A message to echo back.
 
 ## Contributing

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ features:
     details: We dont re-invent the wheel.
   - icon: 🤝
     title: Claude's new best friend
-    details: Let Claude use Gemini naturally, because 3 is a party. 
+    details: Let Claude use Gemini naturally, because 3 is a party.
   - icon: 🔌
     title: MCP Standards
     details: |
@@ -35,6 +35,12 @@ features:
   - icon: 🚦
     title: Model Selection
     details: Choose from Gemini-2.5-Pro and Gemini-2.5-Flash, using natural language.
+  - icon: 🧠
+    title: Structured Brainstorming
+    details: Generate creative ideas with SCAMPER, design thinking, or lateral thinking frameworks.
+  - icon: 📦
+    title: Large Edit Handling
+    details: Change-mode responses can be chunked and retrieved on demand.
 ---
 
 <div class="explore-hint" style="text-align: center; margin: 32px 0 48px; position: relative;">

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -1,3 +1,4 @@
+
 # Commands Reference
 
 Complete list of available commands and their usage.
@@ -19,6 +20,20 @@ Execute code in a safe environment.
 ```
 /gemini-cli:sandbox create a Python fibonacci generator
 /gemini-cli:sandbox test this function: [code]
+```
+
+### `/gemini-cli:brainstorm`
+Generate structured ideas using creative methodologies.
+
+```
+/gemini-cli:brainstorm prompt:"Improve onboarding flow" methodology:scamper ideaCount:8
+```
+
+### `/gemini-cli:fetch-chunk`
+Retrieve additional change-mode edits using a cache key and chunk index.
+
+```
+/gemini-cli:fetch-chunk cacheKey=<key> chunkIndex=2
 ```
 
 ### `/gemini-cli:help`
@@ -43,7 +58,7 @@ Test connectivity with Gemini.
 /gemini-cli:<tool> [options] <arguments>
 ```
 
-- **tool**: The action to perform (analyze, sandbox, help, ping)
+- **tool**: The action to perform (analyze, sandbox, brainstorm, fetch-chunk, help, ping)
 - **options**: Optional flags (coming soon)
 - **arguments**: Input text, files, or questions
 
@@ -97,6 +112,18 @@ Instead of slash commands, you can use natural language:
 ### Code Generation
 ```
 /gemini-cli:analyze @models/user.js generate TypeScript types for this model
+```
+
+### Structured Edits and Chunks
+```
+/gemini-cli:analyze @src/**/*.ts changeMode:true
+# Fetch subsequent edits
+/gemini-cli:fetch-chunk cacheKey=<key> chunkIndex=2
+```
+
+### Brainstorming Ideas
+```
+/gemini-cli:brainstorm prompt:"New product features" methodology:design-thinking includeAnalysis:false
 ```
 
 ## Tips

--- a/docs/usage/examples.md
+++ b/docs/usage/examples.md
@@ -1,3 +1,4 @@
+
 # Real-World Examples
 
 Practical examples of using Gemini MCP Tool in development workflows.
@@ -92,6 +93,13 @@ give me an overview of this project's architecture
 @src/auth/*.js does this follow security best practices?
 ```
 
+## Brainstorming
+
+### Generating Ideas
+```
+/gemini-cli:brainstorm prompt:"Ways to improve developer onboarding" methodology:design-thinking ideaCount:6
+```
+
 ## Migration
 
 ### Framework Upgrade
@@ -129,6 +137,18 @@ identify performance bottlenecks in the request pipeline
 ### Memory Leaks
 ```
 @src/**/*.js look for potential memory leaks or inefficient patterns
+```
+
+## Handling Large Edits
+
+When change mode returns more edits than fit in a single message, Gemini caches the response. Use `fetch-chunk` to continue.
+
+```bash
+# Initial request
+/gemini-cli:analyze @src/**/*.ts changeMode:true
+
+# Retrieve the next chunk
+/gemini-cli:fetch-chunk cacheKey=<key> chunkIndex=2
 ```
 
 ## Real Project Example


### PR DESCRIPTION
## Summary
- document new brainstorming and fetch-chunk tools
- cover changeMode chunk retrieval in command and example docs
- highlight brainstorming and large edit support on docs site
- fix outdated slash command examples

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fc1cadbc0832a919cd70249255f10

## Summary by Sourcery

Document brainstorming and change-mode chunk retrieval features across the README, command reference, usage examples, and site index.

Documentation:
- Add Brainstorming Sessions section and /gemini-cli:brainstorm command with options to README, commands reference, and examples, updating slash command syntax
- Document changeMode edit suggestions and /gemini-cli:fetch-chunk chunk retrieval in README, commands reference, and examples
- Update usage examples to demonstrate brainstorming workflows and large edit handling
- Highlight Structured Brainstorming and Large Edit Handling features on the docs index page