### PR TITLE
Use dedicated console methods in Logger

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -7,7 +7,7 @@ export class Logger {
   }
 
   static log(message: string, ...args: any[]): void {
-    console.warn(this.formatMessage(message), ...args);
+    console.log(this.formatMessage(message), ...args);
   }
 
   static warn(message: string, ...args: any[]): void {
@@ -19,7 +19,7 @@ export class Logger {
   }
 
   static debug(message: string, ...args: any[]): void {
-    console.warn(this.formatMessage(message), ...args);
+    console.debug(this.formatMessage(message), ...args);
   }
 
   static toolInvocation(toolName: string, args: any): void {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Logger } from '../src/utils/logger.js';
+import { LOG_PREFIX } from '../src/constants.js';
+
+describe('Logger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses console.log for log', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    Logger.log('hello', 'world');
+    expect(spy).toHaveBeenCalledWith(`${LOG_PREFIX} hello\n`, 'world');
+  });
+
+  it('uses console.warn for warn', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    Logger.warn('warning');
+    expect(spy).toHaveBeenCalledWith(`${LOG_PREFIX} warning\n`);
+  });
+
+  it('uses console.error for error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    Logger.error('problem');
+    expect(spy).toHaveBeenCalledWith(`${LOG_PREFIX} problem\n`);
+  });
+
+  it('uses console.debug for debug', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    Logger.debug('details');
+    expect(spy).toHaveBeenCalledWith(`${LOG_PREFIX} details\n`);
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure `Logger.log` uses `console.log` and `Logger.debug` uses `console.debug` for proper log levels
- Add unit tests verifying each `Logger` method routes to the correct console function

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d973bbe0832aa0acabce96ac66c0