### PR TITLE
chore: type tool arguments

### DIFF
--- a/src/tools/ask-gemini.tool.ts
+++ b/src/tools/ask-gemini.tool.ts
@@ -51,7 +51,7 @@ export const askGeminiTool: UnifiedTool<AskGeminiArgs> = {
     if (changeMode) {
       return processChangeModeOutput(
         result,
-        chunkIndex as number | undefined,
+        chunkIndex !== undefined ? Number(chunkIndex) : undefined,
         undefined,
         prompt
       );

--- a/src/tools/ask-gemini.tool.ts
+++ b/src/tools/ask-gemini.tool.ts
@@ -34,8 +34,8 @@ export const askGeminiTool: UnifiedTool<AskGeminiArgs> = {
     if (changeMode && chunkIndex && chunkCacheKey) {
       return processChangeModeOutput(
         '', // empty for cache...
-        chunkIndex as number,
-        chunkCacheKey as string,
+        Number(chunkIndex),
+        chunkCacheKey,
         prompt
       );
     }

--- a/src/tools/brainstorm.tool.ts
+++ b/src/tools/brainstorm.tool.ts
@@ -126,7 +126,9 @@ const brainstormArgsSchema = z.object({
   includeAnalysis: z.boolean().default(true).describe("Include feasibility, impact, and implementation analysis for generated ideas"),
 });
 
-export const brainstormTool: UnifiedTool = {
+type BrainstormArgs = z.infer<typeof brainstormArgsSchema>;
+
+export const brainstormTool: UnifiedTool<BrainstormArgs> = {
   name: "brainstorm",
   description: "Generate novel ideas with dynamic context gathering. --> Creative frameworks (SCAMPER, Design Thinking, etc.), domain context integration, idea clustering, feasibility analysis, and iterative refinement.",
   zodSchema: brainstormArgsSchema,
@@ -134,7 +136,7 @@ export const brainstormTool: UnifiedTool = {
     description: "Generate structured brainstorming prompt with methodology-driven ideation, domain context integration, and analytical evaluation framework",
   },
   category: 'gemini',
-  execute: async (args, onProgress) => {
+  execute: async (args: BrainstormArgs, onProgress) => {
     const {
       prompt,
       model,
@@ -151,21 +153,21 @@ export const brainstormTool: UnifiedTool = {
     }
 
     let enhancedPrompt = buildBrainstormPrompt({
-      prompt: prompt.trim() as string,
-      methodology: methodology as string,
-      domain: domain as string | undefined,
-      constraints: constraints as string | undefined,
-      existingContext: existingContext as string | undefined,
-      ideaCount: ideaCount as number,
-      includeAnalysis: includeAnalysis as boolean
+      prompt: prompt.trim(),
+      methodology,
+      domain,
+      constraints,
+      existingContext,
+      ideaCount,
+      includeAnalysis
     });
 
     Logger.debug(`Brainstorm: Using methodology '${methodology}' for domain '${domain || 'general'}'`);
     
     // Report progress to user
     onProgress?.(`Generating ${ideaCount} ideas via ${methodology} methodology...`);
-    
+
     // Execute with Gemini
-    return await executeGeminiCLI(enhancedPrompt, model as string | undefined, false, false, onProgress);
+    return await executeGeminiCLI(enhancedPrompt, model, false, false, onProgress);
   }
 };

--- a/src/tools/fetch-chunk.tool.ts
+++ b/src/tools/fetch-chunk.tool.ts
@@ -9,7 +9,9 @@ const inputSchema = z.object({
   chunkIndex: z.number().min(1).describe("Which chunk to retrieve (1-based index)")
 });
 
-export const fetchChunkTool: UnifiedTool = {
+type FetchChunkArgs = z.infer<typeof inputSchema>;
+
+export const fetchChunkTool: UnifiedTool<FetchChunkArgs> = {
   name: 'fetch-chunk',
   description: 'Retrieves cached chunks from a changeMode response. Use this to get subsequent chunks after receiving a partial changeMode response.',
   
@@ -28,7 +30,7 @@ export const fetchChunkTool: UnifiedTool = {
   
   category: 'utility',
   
-  execute: async (args: any, onProgress?: (newOutput: string) => void): Promise<string> => {
+  execute: async (args: FetchChunkArgs, onProgress?: (newOutput: string) => void): Promise<string> => {
     const { cacheKey, chunkIndex } = args;
     
     Logger.toolInvocation('fetch-chunk', args);

--- a/src/tools/simple-tools.ts
+++ b/src/tools/simple-tools.ts
@@ -6,7 +6,9 @@ const pingArgsSchema = z.object({
   prompt: z.string().default('').describe("Message to echo "),
 });
 
-export const pingTool: UnifiedTool = {
+type PingArgs = z.infer<typeof pingArgsSchema>;
+
+export const pingTool: UnifiedTool<PingArgs> = {
   name: "ping",
   description: "Echo",
   zodSchema: pingArgsSchema,
@@ -14,15 +16,17 @@ export const pingTool: UnifiedTool = {
     description: "Echo test message with structured response.",
   },
   category: 'simple',
-  execute: async (args, onProgress) => {
-    const message = args.prompt || args.message || "Pong!";
-    return executeCommand("echo", [message as string], onProgress);
+  execute: async (args: PingArgs, onProgress) => {
+    const message = args.prompt || "Pong!";
+    return executeCommand("echo", [message], onProgress);
   }
 };
 
 const helpArgsSchema = z.object({});
 
-export const helpTool: UnifiedTool = {
+type HelpArgs = z.infer<typeof helpArgsSchema>;
+
+export const helpTool: UnifiedTool<HelpArgs> = {
   name: "Help",
   description: "receive help information",
   zodSchema: helpArgsSchema,
@@ -30,7 +34,7 @@ export const helpTool: UnifiedTool = {
     description: "receive help information",
   },
   category: 'simple',
-  execute: async (args, onProgress) => {
+  execute: async (_args: HelpArgs, onProgress) => {
     return executeCommand("gemini", ["-help"], onProgress);
   }
 };

--- a/src/tools/timeout-test.tool.ts
+++ b/src/tools/timeout-test.tool.ts
@@ -16,7 +16,7 @@ export const timeoutTestTool: UnifiedTool<TimeoutTestArgs> = {
   },
   category: 'simple',
   execute: async (args: TimeoutTestArgs, onProgress) => {
-    const duration = args.duration;
+    const {duration} = args;
     const steps = Math.ceil(duration / 5000); // Progress every 5 seconds
     const stepDuration = duration / steps;
     const startTime = Date.now();

--- a/src/tools/timeout-test.tool.ts
+++ b/src/tools/timeout-test.tool.ts
@@ -5,7 +5,9 @@ const timeoutTestArgsSchema = z.object({
   duration: z.number().min(10).describe("Duration in milliseconds (minimum 10ms)"),
 });
 
-export const timeoutTestTool: UnifiedTool = {
+type TimeoutTestArgs = z.infer<typeof timeoutTestArgsSchema>;
+
+export const timeoutTestTool: UnifiedTool<TimeoutTestArgs> = {
   name: "timeout-test",
   description: "Test timeout prevention by running for a specified duration",
   zodSchema: timeoutTestArgsSchema,
@@ -13,8 +15,8 @@ export const timeoutTestTool: UnifiedTool = {
     description: "Test the timeout prevention system by running a long operation",
   },
   category: 'simple',
-  execute: async (args, onProgress) => {
-    const duration = args.duration as number;
+  execute: async (args: TimeoutTestArgs, onProgress) => {
+    const duration = args.duration;
     const steps = Math.ceil(duration / 5000); // Progress every 5 seconds
     const stepDuration = duration / steps;
     const startTime = Date.now();


### PR DESCRIPTION
## Summary
- define argument types for tools with `z.infer` and use them in execute signatures
- make tool registry generic to support typed tool arguments
- streamline ping tool implementation

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d9681c74832a814af016f10eaaf9

## Summary by Sourcery

Add strong typing for tool arguments using Zod schemas and TypeScript generics, update the tool registry and execution functions accordingly, and streamline tool implementations.

Enhancements:
- Make UnifiedTool and executeTool generic over parsed argument types
- Infer each tools argument type via z.infer and annotate tool exports and execute signatures
- Remove manual casts inside execute functions and leverage typed args
- Simplify pingTool implementation by removing redundant fallback logic