### PR TITLE
chore: skip docs deploy on forks

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,7 @@ jobs:
           path: docs/.vitepress/dist
 
   deploy:
+    if: github.repository == 'jamubc/gemini-mcp-tool'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- avoid deploying docs from forked repositories by gating the deploy job to the upstream repo

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899df46075c832a8cda7bf70316a073

## Summary by Sourcery

CI:
- Add an if condition to the deploy-docs GitHub Actions workflow to only run on the jamubc/gemini-mcp-tool repository.