### PR TITLE
Remove trailing newline from log messages

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,7 +3,7 @@ import { LOG_PREFIX } from "../constants.js";
 
 export class Logger {
   private static formatMessage(message: string): string {
-    return `${LOG_PREFIX} ${message}` + "\n";
+    return `${LOG_PREFIX} ${message}`;
   }
 
   static log(message: string, ...args: any[]): void {

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -8,10 +8,10 @@ describe('Logger', () => {
   });
 
   it.each([
-    { level: 'log', message: 'hello', args: ['world'], expectedMsg: `${LOG_PREFIX} hello\n` },
-    { level: 'warn', message: 'warning', args: [], expectedMsg: `${LOG_PREFIX} warning\n` },
-    { level: 'error', message: 'problem', args: [], expectedMsg: `${LOG_PREFIX} problem\n` },
-    { level: 'debug', message: 'details', args: [], expectedMsg: `${LOG_PREFIX} details\n` },
+    { level: 'log', message: 'hello', args: ['world'], expectedMsg: `${LOG_PREFIX} hello` },
+    { level: 'warn', message: 'warning', args: [], expectedMsg: `${LOG_PREFIX} warning` },
+    { level: 'error', message: 'problem', args: [], expectedMsg: `${LOG_PREFIX} problem` },
+    { level: 'debug', message: 'details', args: [], expectedMsg: `${LOG_PREFIX} details` },
   ])('uses console.%s for %s', ({ level, message, args, expectedMsg }) => {
     const spy = vi
       .spyOn(console, level as keyof Console)


### PR DESCRIPTION
## Summary
- Stop appending a newline in `formatMessage` so logs match expected format
- Update logger tests to expect messages without trailing newline

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899df5ab80c832a9cdfeec0d5ab11b4